### PR TITLE
feature:[EGRE-3176] EOS Web Service: add DeleteLoadSetterInputs to ILoadSetterInputProvider & LoadSetterInputProvider

### DIFF
--- a/.github/workflows/update-pull-request-description.yml
+++ b/.github/workflows/update-pull-request-description.yml
@@ -41,4 +41,3 @@ jobs:
         with:
           slackWebhookUrl: ${{ secrets.SLACK_WEBHOOK_URL }}
           title: ${{ steps.update-pr.outputs.title }}
-        


### PR DESCRIPTION
# [EGRE-3176](https://originenergy.atlassian.net//browse/EGRE-3176) - EOS Web Service: add DeleteLoadSetterInputs to ILoadSetterInputProvider EOS Web Service: add DeleteLoadSetterInputs to ILoadSetterInputProvider EOS Web Service: add DeleteLoadSetterInputs to ILoadSetterInputProvider {{TICKET_TITLE}} LoadSetterInputProvider LoadSetterInputProvider LoadSetterInputProvider

![Pipeline](https://github.com/gavanlamb/gavanlamb.github.io/actions/workflows/preview.yml/badge.svg?event=pull_request&branch=feature/EGRE-3176-test-pipelines)
![Version](https://gavanlamb-github-actions-assets.s3.ap-southeast-2.amazonaws.com/gavanlamb/gavanlamb.github.io/feature/EGRE-3176-test-pipelines/site/badges/version.svg)
[Website](https://gavanlamb-github-actions-assets.s3.ap-southeast-2.amazonaws.com/gavanlamb/gavanlamb.github.io/feature/EGRE-3176-test-pipelines/site/index.html)

## Description
*
*
*

## Testing
- [ ] Deployed to S3