### PR TITLE
fix:[SCRUM-31] Include website in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,12 +132,19 @@ jobs:
         with:
           name: ${{ env.artifact-name }}
           path: site
+      - name: Does tag exist
+        shell: bash
+        id: rename-website-artifact
+        run: |
+          NAME="website.tar"
+          mv site/artifact.tar $NAME
+          echo "path=$NAME" >> $GITHUB_OUTPUT
       - name: Create GitHub release
         uses: gavanlamb/github-actions/.github/actions/release/create-release@main
         with:
           tag-name: ${{ steps.create-tag-name.outputs.name }}
           files: |
-            site/artifact.tar
+            ${{ steps.rename-website-artifact.outputs.path }}
       # close all jira tickets
       # close Jira release
       # send message release is a success


### PR DESCRIPTION
# [SCRUM-31](https://gavanlamb-team-1vid7fblvall.atlassian.net/browse/SCRUM-31) - Include website in release

![Pipeline](https://github.com/gavanlamb/gavanlamb.github.io/actions/workflows/pull-request.pushed.yml/badge.svg?event=pull_request&branch=fix/SCRUM-31-rename-website-artifact)
![Version](https://gavanlamb-github-actions-assets.s3.ap-southeast-2.amazonaws.com/gavanlamb/gavanlamb.github.io/release/preview107/site/badges/version.svg)
[Website](https://gavanlamb-github-actions-assets.s3.ap-southeast-2.amazonaws.com/gavanlamb/gavanlamb.github.io/release/preview107/site/index.html)

## Description
*
*
*

## Testing
- [ ] Deployed to S3